### PR TITLE
allowing project version to be passed in

### DIFF
--- a/addon/components/search-input.js
+++ b/addon/components/search-input.js
@@ -17,6 +17,7 @@ export default Component.extend({
 
   // Public API
   value: '',
+  projectVersion: 'v3.0.0',
 
   _searchClient: service('algolia'),
 
@@ -39,7 +40,7 @@ export default Component.extend({
 
     const client = get(this, '_searchClient');
     // const projectVersion = get(this, '_projectVersion');
-    const projectVersion = 'v2.16.0';
+    const projectVersion = get(this, 'projectVersion');
 
     // Hide and don't run query if there's no search query
     // if (!query) {


### PR DESCRIPTION
Howdy 👋 

The current implementation of the search components is currently "good enough" to be used in the Guides app. https://github.com/ember-learn/guides-app/pull/39 depends on this branch to work and it's working well 🎉 

I don't quite know what you were trying to do with the project service but I added the "projectVersion" to the public API of the search component with a sensible default. Let me know if you have any questions.

I would love to get this merged and then for us to think about merging that initial setup branch into master because I'm assuming Guides App is the only one using this addon for now? 