### PR TITLE
Limiting search results to only guides

### DIFF
--- a/addon/components/search-input.js
+++ b/addon/components/search-input.js
@@ -50,7 +50,7 @@ export default Component.extend({
     const params = {
       hitsPerPage: 15,
       restrictSearchableAttributes: ['hierarchy.lvl0', 'hierarchy.lvl1', 'hierarchy.lvl2', 'hierarchy.lvl3', 'hierarchy.lvl4'],
-      facetFilters: [[`version:${projectVersion}`,'tags:api']]
+      facetFilters: [[`version:${projectVersion}`]]
     };
 
     const searchObj = {

--- a/addon/templates/components/search-input.hbs
+++ b/addon/templates/components/search-input.hbs
@@ -6,6 +6,7 @@
   onfocus={{action 'onfocus'}}
     onblur={{action 'onblur'}}
   placeholder="Search the guides"
+  autocomplete="off"
 >
 
 {{!-- Search results dropdown --}}

--- a/index.js
+++ b/index.js
@@ -2,5 +2,8 @@
 'use strict';
 
 module.exports = {
-  name: 'ember-learn-search-components'
+  name: 'ember-learn-search-components',
+  included: function(/* app */) {
+    this._super.included.apply(this, arguments);
+  },
 };


### PR DESCRIPTION
This PR just removes the API results from the search components temporarily. Fixes: https://github.com/ember-learn/guides-app/issues/51

As guides (and soon deprecations) are the only ones using this addon this is not going to have wide-reaching repercussions. 